### PR TITLE
fix for duckdb v1.3.0

### DIFF
--- a/chsql/src/duck_flock.cpp
+++ b/chsql/src/duck_flock.cpp
@@ -104,7 +104,7 @@ namespace duckdb {
             
             try {
                 if (res->TryFetch(data_chunk, error_data)) {
-                    if (data_chunk && !data_chunk->size() == 0) {
+                    if (data_chunk && data_chunk->size() != 0) {
                         output.Append(*data_chunk);
                         return;
                     }


### PR DESCRIPTION
This PR addresses fixes related to duckdb v1.3.0, including fixes for parquet scan.